### PR TITLE
Fix: #36 SwiperPluginKeyboardControl exported incorrectly 

### DIFF
--- a/src/index.esm.js
+++ b/src/index.esm.js
@@ -2,6 +2,6 @@ import Swiper from './core.js'
 
 export { default as SwiperPluginLazyload } from './modules/lazyload.js'
 export { default as SwiperPluginPagination } from './modules/pagination.js'
-export { default as SwiperPluginKeyboardControl } from './modules/pagination.js'
+export { default as SwiperPluginKeyboardControl } from './modules/keyboardControl.js'
 
 export default Swiper

--- a/test/unit/init.spec.js
+++ b/test/unit/init.spec.js
@@ -225,7 +225,6 @@ describe('Initialization', function () {
         expect(data.instance).toMatchObject(match)
     })
 
-
     it('slidesPerView parameter - scroll to last slide', async function () {
         await page.addScriptTag({
             type: 'module',
@@ -262,7 +261,6 @@ describe('Initialization', function () {
         // eslint-disable-next-line
         expect(data.transform).toEqual(-parseInt(instance.slideSize * instance.$list.length - instance.viewSize - instance.config.spaceBetween, 10))
     })
-
 
     it('centeredSlides parameter', async function () {
         await page.addScriptTag({

--- a/test/unit/wheelAction.spec.js
+++ b/test/unit/wheelAction.spec.js
@@ -1,6 +1,6 @@
 const puppeteer = require('puppeteer')
 const pti = require('puppeteer-to-istanbul')
-const helper = require('./../helper')
+const helper = require('../helper')
 
 describe('Wheel Action', () => {
     let page = null


### PR DESCRIPTION
- Fix SwiperPluginKeyboardControl import https://github.com/joe223/tiny-swiper/issues/36
- Fix eslint errors