### PR TITLE
fix/disable-button => fix for the disabling of the prev and next butt…

### DIFF
--- a/packages/tiny-swiper/lib/index.esm.js
+++ b/packages/tiny-swiper/lib/index.esm.js
@@ -368,11 +368,11 @@ var SwiperPluginNavigation = (function SwiperPluginNavigation(instance, options)
         maxIndex = _instance$env$limitat.maxIndex;
 
     if (navigationInstance && navigationInstance.prevEl && navigationInstance.nextEl) {
-      if (navigationInstance.nextEl.classList.contains(navigationOptions.disabledClass) && index > minIndex) {
+      if (navigationInstance.nextEl.classList.contains(navigationOptions.disabledClass) && index >= minIndex) {
         navigationInstance.nextEl.classList.remove(navigationOptions.disabledClass);
       }
 
-      if (navigationInstance.prevEl.classList.contains(navigationOptions.disabledClass) && index < maxIndex) {
+      if (navigationInstance.prevEl.classList.contains(navigationOptions.disabledClass) && index <= maxIndex) {
         navigationInstance.prevEl.classList.remove(navigationOptions.disabledClass);
       }
 

--- a/packages/tiny-swiper/lib/modules/navigation.js
+++ b/packages/tiny-swiper/lib/modules/navigation.js
@@ -51,11 +51,11 @@
             maxIndex = _instance$env$limitat.maxIndex;
 
         if (navigationInstance && navigationInstance.prevEl && navigationInstance.nextEl) {
-          if (navigationInstance.nextEl.classList.contains(navigationOptions.disabledClass) && index > minIndex) {
+          if (navigationInstance.nextEl.classList.contains(navigationOptions.disabledClass) && index >= minIndex) {
             navigationInstance.nextEl.classList.remove(navigationOptions.disabledClass);
           }
 
-          if (navigationInstance.prevEl.classList.contains(navigationOptions.disabledClass) && index < maxIndex) {
+          if (navigationInstance.prevEl.classList.contains(navigationOptions.disabledClass) && index <= maxIndex) {
             navigationInstance.prevEl.classList.remove(navigationOptions.disabledClass);
           }
 

--- a/packages/tiny-swiper/src/modules/navigation.ts
+++ b/packages/tiny-swiper/src/modules/navigation.ts
@@ -70,11 +70,11 @@ export default <SwiperPlugin>function SwiperPluginNavigation (
             && navigationInstance!.nextEl
         ) {
             if (navigationInstance.nextEl.classList.contains(navigationOptions.disabledClass)
-                && index > minIndex) {
+                && index >= minIndex) {
                 navigationInstance.nextEl.classList.remove(navigationOptions.disabledClass)
             }
             if (navigationInstance.prevEl.classList.contains(navigationOptions.disabledClass)
-                && index < maxIndex) {
+                && index <= maxIndex) {
                 navigationInstance.prevEl.classList.remove(navigationOptions.disabledClass)
             }
 


### PR DESCRIPTION
Describe the bug
When setting the loop option to false and the slider has no more than 2 slides the previous and next buttons will disable incorrectly. When user navigates to the last slide both navigation buttons are disabled.

The issue occurs in the navigation plugin at the checkNavBtnDisabledClass. By updating the condition in
index > minIndex to index >= minIndex and index < minIndex to index <= maxIndex I'm able to see the disable classes working correctly. Is this a known bug that will be fixed in the next release of tiny-swiper ?

Expected behaviour
If the slider has 2 or less slides and loop is set to false the nextEl should be disabled when user is at the last slide and the prevEl should not be disabled. When user is at the first slide the prevEl should be disabled and the nextEl should not be disabled

Information

relates to [issue 60](https://github.com/joe223/tiny-swiper/issues/60)