### PR TITLE
Removing shallow slides from $list

### DIFF
--- a/packages/tiny-swiper/src/core/env/element.ts
+++ b/packages/tiny-swiper/src/core/env/element.ts
@@ -12,7 +12,8 @@ export function Element (
 ): Element {
     const $el = <HTMLElement>(typeof el === 'string' ? document.body.querySelector(el) : el)
     const $wrapper = <HTMLElement>$el!.querySelector(`.${options.wrapperClass}`)
-    const $list = [].slice.call($el!.getElementsByClassName(options.slideClass))
+    let $list = [].slice.call($el!.getElementsByClassName(options.slideClass))
+    $list = $list.filter((slide: HTMLElement) => slide.getAttribute('data-shallow-slider') === null)
 
     return {
         $el,


### PR DESCRIPTION
This PR attemps to fix the following [issue](https://github.com/joe223/tiny-swiper/issues/74)
 
Since **Element** is not active removing shallow slides from $list, maxIndex calculation will be wrong for the scenario:

- Loop mode on
- Resize update activated